### PR TITLE
Add an option to reset the backends in between scans. (Fixes #2 in a way)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Any backend not being matched by the regexp will be labeled as `unknown`.
       	Port of Varnish to connect to (default 6082)
     -varnish.secret string
       	Filename of varnish secret file (default "/etc/varnish/secret")
+    -varnish.reset
+      	Reset backend information in between scans. (default false)
+      	This prevents reporting on removed backends.
     -version
       	Print version information.
     -web.listen-address string

--- a/varnishbackend_exporter.go
+++ b/varnishbackend_exporter.go
@@ -112,6 +112,7 @@ func main() {
 		varnishInterval = flag.Int("varnish.interval", 15, "Varnish checking interval")
 		directorReStr   = flag.String("directorre", "", "Regular expression extracting director name from backend name")
 		showVersion     = flag.Bool("version", false, "Print version information.")
+		resetBackends   = flag.Bool("varnish.reset", false, "Reset the backends list after each scan.")
 	)
 	flag.Parse()
 
@@ -239,6 +240,11 @@ func main() {
 					}
 				}
 			}
+
+			if *resetBackends {
+				prombackends.Reset()
+			}
+
 			if directorRegexp != nil {
 				for k := range labelall {
 					prombackends.With(prometheus.Labels{"state": "healthy", "director": k}).Set(float64(labelhealthy[k]))


### PR DESCRIPTION
This allows cleaning up old backends that are no longer reported
by backend.list. This happens quite often when you use dynamic
backends for example.

This provides a workaround for #2 